### PR TITLE
Publication-quality loss-component + train/test summary figures

### DIFF
--- a/src/genome_minimizer_2/training/evaluation/visualise.py
+++ b/src/genome_minimizer_2/training/evaluation/visualise.py
@@ -12,7 +12,10 @@ import seaborn as sns
 from sklearn.decomposition import PCA
 from typing import List, Optional
 import os
-from src.genome_minimizer_2.utils.extras import get_latent_variables
+from src.genome_minimizer_2.utils.extras import (
+    get_latent_variables, plot_loss_components,
+    _PUB_RC, _TRAIN_COLOR, _VAL_COLOR, _TEST_COLOR,
+)
 
 # Set device
 device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
@@ -176,84 +179,98 @@ def plot_reconstruction_examples(model, test_loader, output_dir: str,
                     break
 
 
-def create_training_summary_plot(train_losses: List[float], val_losses: List[float], 
-                                f1_scores: List[float], accuracy_scores: List[float],
-                                output_dir: str, model_name: str = "VAE") -> None:
+def _distribution_panel(ax, train_vals, test_vals, xlabel, title):
+    """Overlaid train-vs-test density histogram with mean markers."""
+    train_vals = np.asarray(train_vals, dtype=float)
+    test_vals = np.asarray(test_vals, dtype=float)
+    lo = min(train_vals.min(), test_vals.min())
+    hi = max(train_vals.max(), test_vals.max())
+    bins = np.linspace(lo, hi, 28) if hi > lo else 28
+    ax.hist(train_vals, bins=bins, color=_TRAIN_COLOR, alpha=0.55, density=True, label="Train")
+    ax.hist(test_vals, bins=bins, color=_TEST_COLOR, alpha=0.55, density=True, label="Test")
+    ax.axvline(train_vals.mean(), color=_TRAIN_COLOR, ls="--", lw=1.2)
+    ax.axvline(test_vals.mean(), color=_TEST_COLOR, ls="--", lw=1.2)
+    ax.set_title(title)
+    ax.set_xlabel(xlabel)
+    ax.set_ylabel("Density")
+    ax.spines["top"].set_visible(False)
+    ax.spines["right"].set_visible(False)
+    ax.grid(True, axis="y", ls=":", lw=0.6, alpha=0.4)
+    ax.legend()
+
+
+def create_training_summary_plot(train_losses: List[float], val_losses: List[float],
+                                f1_test: List[float], accuracy_test: List[float],
+                                output_dir: str, model_name: str = "VAE",
+                                f1_train: Optional[List[float]] = None,
+                                accuracy_train: Optional[List[float]] = None) -> None:
     """
-    Create a comprehensive summary plot of training results.
-    
+    Publication-quality training summary: total loss curve, train-vs-test
+    distributions of per-sample reconstruction F1 and accuracy, and a compact
+    stats table.
+
     Args:
-        train_losses: Training loss values
-        val_losses: Validation loss values
-        f1_scores: Per-sample F1 scores
-        accuracy_scores: Per-sample accuracy scores
-        output_dir: Directory to save plots
-        model_name: Name of the model for titles
+        train_losses, val_losses: per-epoch total loss.
+        f1_test, accuracy_test: per-sample reconstruction metrics on the test set.
+        output_dir: directory to save into.
+        model_name: title / filename stem.
+        f1_train, accuracy_train: per-sample metrics on the train set. When given,
+            the distribution panels overlay train vs test; otherwise test only.
     """
     os.makedirs(output_dir, exist_ok=True)
-    
-    fig, axes = plt.subplots(2, 2, figsize=(12, 10), dpi=300)
-    
-    # Training curves
-    epochs = range(1, len(train_losses) + 1)
-    axes[0, 0].plot(epochs, train_losses, label='Training Loss', color='blue', alpha=0.8)
-    axes[0, 0].plot(epochs, val_losses, label='Validation Loss', color='red', alpha=0.8)
-    axes[0, 0].set_xlabel('Epochs')
-    axes[0, 0].set_ylabel('Loss')
-    axes[0, 0].set_title(f'{model_name} Training Curves')
-    axes[0, 0].legend()
-    axes[0, 0].grid(True, alpha=0.3)
-    
-    # F1 score distribution
-    axes[0, 1].hist(f1_scores, bins=30, alpha=0.7, color='green', edgecolor='black')
-    axes[0, 1].axvline(np.mean(f1_scores), color='darkgreen', linestyle='--', 
-                       label=f'Mean: {np.mean(f1_scores):.3f}')
-    axes[0, 1].set_xlabel('F1 Score')
-    axes[0, 1].set_ylabel('Frequency')
-    axes[0, 1].set_title('F1 Score Distribution')
-    axes[0, 1].legend()
-    axes[0, 1].grid(True, alpha=0.3)
-    
-    # Accuracy distribution
-    axes[1, 0].hist(accuracy_scores, bins=30, alpha=0.7, color='purple', edgecolor='black')
-    axes[1, 0].axvline(np.mean(accuracy_scores), color='darkviolet', linestyle='--', 
-                       label=f'Mean: {np.mean(accuracy_scores):.3f}')
-    axes[1, 0].set_xlabel('Accuracy Score')
-    axes[1, 0].set_ylabel('Frequency')
-    axes[1, 0].set_title('Accuracy Distribution')
-    axes[1, 0].legend()
-    axes[1, 0].grid(True, alpha=0.3)
-    
-    # Summary statistics
-    axes[1, 1].axis('off')
-    summary_text = f"""
-    {model_name} Training Summary
 
-    Final Training Loss: {train_losses[-1]:.4f}
-    Final Validation Loss: {val_losses[-1]:.4f}
+    # Fall back to test-only if train metrics weren't supplied.
+    f1_tr = np.asarray(f1_train if f1_train is not None else f1_test, dtype=float)
+    acc_tr = np.asarray(accuracy_train if accuracy_train is not None else accuracy_test, dtype=float)
+    f1_te = np.asarray(f1_test, dtype=float)
+    acc_te = np.asarray(accuracy_test, dtype=float)
 
-    F1 Score Statistics:
-    - Mean: {np.mean(f1_scores):.4f}
-    - Std:  {np.std(f1_scores):.4f}
-    - Min:  {np.min(f1_scores):.4f}
-    - Max:  {np.max(f1_scores):.4f}
+    with plt.rc_context(_PUB_RC):
+        fig, axes = plt.subplots(2, 2, figsize=(8.2, 6.4), constrained_layout=True)
 
-    Accuracy Statistics:
-    - Mean: {np.mean(accuracy_scores):.4f}
-    - Std:  {np.std(accuracy_scores):.4f}
-    - Min:  {np.min(accuracy_scores):.4f}
-    - Max:  {np.max(accuracy_scores):.4f}
+        # Total loss
+        ep = np.arange(1, len(train_losses) + 1)
+        axes[0, 0].plot(ep, train_losses, color=_TRAIN_COLOR, lw=1.6, label="Train")
+        axes[0, 0].plot(ep, val_losses, color=_VAL_COLOR, lw=1.6, ls="--", label="Validation")
+        axes[0, 0].set_title("Total loss")
+        axes[0, 0].set_xlabel("Epoch")
+        axes[0, 0].set_ylabel("Loss")
+        axes[0, 0].spines["top"].set_visible(False)
+        axes[0, 0].spines["right"].set_visible(False)
+        axes[0, 0].grid(True, ls=":", lw=0.6, alpha=0.4)
+        axes[0, 0].legend()
+        axes[0, 0].ticklabel_format(axis="y", style="sci", scilimits=(-3, 4))
 
-    Total Epochs: {len(train_losses)}
-    """
-    axes[1, 1].text(0.1, 0.9, summary_text, transform=axes[1, 1].transAxes, 
-                     fontsize=11, verticalalignment='top', 
-                     bbox=dict(boxstyle='round', facecolor='lightgray', alpha=0.5))
-    
-    plt.tight_layout()
-    plt.savefig(os.path.join(output_dir, f"{model_name}_training_summary.pdf"), 
-               format="pdf", bbox_inches="tight")
-    plt.close()
+        # Train-vs-test metric distributions
+        _distribution_panel(axes[0, 1], f1_tr, f1_te, "F1 score", "Reconstruction F1")
+        _distribution_panel(axes[1, 0], acc_tr, acc_te, "Accuracy", "Reconstruction accuracy")
+
+        # Compact stats table
+        ax = axes[1, 1]
+        ax.axis("off")
+        rows = [
+            ("", "Train", "Test"),
+            ("F1 (mean)", f"{f1_tr.mean():.3f}", f"{f1_te.mean():.3f}"),
+            ("Accuracy (mean)", f"{acc_tr.mean():.3f}", f"{acc_te.mean():.3f}"),
+            ("Final loss", f"{train_losses[-1]:.2e}", f"{val_losses[-1]:.2e}"),
+            ("Epochs", f"{len(train_losses)}", ""),
+        ]
+        tbl = ax.table(cellText=rows, loc="center", cellLoc="center")
+        tbl.auto_set_font_size(False)
+        tbl.set_fontsize(9)
+        tbl.scale(1, 1.6)
+        for (r, c), cell in tbl.get_celld().items():
+            cell.set_edgecolor("#cccccc")
+            if r == 0:
+                cell.set_text_props(fontweight="bold")
+            if c == 0:
+                cell.set_text_props(ha="left")
+
+        fig.suptitle(f"{model_name} training summary", fontsize=12, fontweight="bold")
+        for ext in ("pdf", "png"):
+            fig.savefig(os.path.join(output_dir, f"{model_name}_training_summary.{ext}"),
+                        bbox_inches="tight")
+        plt.close(fig)
 
 
 # Export all functions

--- a/src/genome_minimizer_2/utils/experiments.py
+++ b/src/genome_minimizer_2/utils/experiments.py
@@ -32,7 +32,7 @@ from src.genome_minimizer_2.training.evaluation.visualise import (
     plot_latent_space_pca,
     create_training_summary_plot
 )
-from src.genome_minimizer_2.utils.extras import plot_loss_vs_epochs_graph
+from src.genome_minimizer_2.utils.extras import plot_loss_vs_epochs_graph, plot_loss_components
 from src.genome_minimizer_2.utils.directories import (
     PROJECT_ROOT,
     ESSENTIAL_GENES_POSITIONS,
@@ -444,6 +444,11 @@ class IntegratedExperimentRunner:
             self.results['train_loss_vals'] = train_loss_vals
             self.results['val_loss_vals'] = val_loss_vals
             self.results['epochs_trained'] = epochs
+            # Per-component loss histories (reconstruction, KL, etc.) for the
+            # component-breakdown plot. The tracker keeps them; train() only
+            # returns the totals.
+            self.results['train_loss_components'] = dict(trainer.loss_tracker.train_losses)
+            self.results['val_loss_components'] = dict(trainer.loss_tracker.val_losses)
 
             self.logger.info(f"Training completed after {epochs} epochs")
             self.logger.info(f"Final train loss: {train_loss_vals[-1]:.4f}")
@@ -475,12 +480,25 @@ class IntegratedExperimentRunner:
             epochs = np.linspace(1, self.results['epochs_trained'], num=self.results['epochs_trained'])
             name = os.path.join(self.figure_dir, f"{self.config.trainer_version}_train_val_loss.pdf")
             plot_loss_vs_epochs_graph(
-                epochs=epochs, 
-                train_loss_vals=self.results['train_loss_vals'], 
-                val_loss_vals=self.results['val_loss_vals'], 
+                epochs=epochs,
+                train_loss_vals=self.results['train_loss_vals'],
+                val_loss_vals=self.results['val_loss_vals'],
                 fig_name=name
             )
             self.logger.info(f"Loss comparison plot saved to {name}")
+
+            # Publication-quality breakdown into loss components (total,
+            # reconstruction, KL, ...). Both PDF (for the paper) and PNG.
+            if 'train_loss_components' in self.results:
+                base = os.path.join(self.figure_dir, f"{self.config.trainer_version}_loss_components")
+                for ext in ("pdf", "png"):
+                    plot_loss_components(
+                        self.results['train_loss_components'],
+                        self.results['val_loss_components'],
+                        fig_name=f"{base}.{ext}",
+                        title=f"VAE training — preset {self.config.trainer_version}",
+                    )
+                self.logger.info(f"Loss-component plot saved to {base}.pdf / .png")
         except Exception as e:
             self.logger.error(f"Error generating comparison plots: {e}")
     
@@ -501,6 +519,14 @@ class IntegratedExperimentRunner:
             self.results['accuracy_overall'] = overall_accuracy
             self.results['f1_scores_per_sample'] = f1_scores
             self.results['accuracy_scores_per_sample'] = accuracy_scores
+
+            # Same per-sample metrics on the train set, for the train-vs-test
+            # distribution panels in the summary figure.
+            _, _, f1_train, accuracy_train = calculate_reconstruction_metrics(
+                self.model, self.train_loader
+            )
+            self.results['f1_scores_per_sample_train'] = f1_train
+            self.results['accuracy_scores_per_sample_train'] = accuracy_train
             
             self.logger.info(f"Overall F1 Score: {overall_f1:.4f}")
             self.logger.info(f"Overall Accuracy: {overall_accuracy:.4f}")
@@ -551,7 +577,9 @@ class IntegratedExperimentRunner:
                 self.results['f1_scores_per_sample'],
                 self.results['accuracy_scores_per_sample'],
                 self.figure_dir,
-                self.config.experiment_name
+                self.config.experiment_name,
+                f1_train=self.results.get('f1_scores_per_sample_train'),
+                accuracy_train=self.results.get('accuracy_scores_per_sample_train'),
             )
             self.logger.info("Summary plot generated")
         except Exception as e:

--- a/src/genome_minimizer_2/utils/extras.py
+++ b/src/genome_minimizer_2/utils/extras.py
@@ -255,6 +255,145 @@ def plot_loss_vs_epochs_graph(epochs, train_loss_vals, val_loss_vals, fig_name):
     plt.close()
 
 
+# Publication styling shared by the component-breakdown figure.
+_PUB_RC = {
+    "figure.dpi": 300,
+    "savefig.dpi": 300,
+    "font.family": "sans-serif",
+    "font.sans-serif": ["Helvetica", "Arial", "DejaVu Sans"],
+    "font.size": 9,
+    "axes.titlesize": 10,
+    "axes.labelsize": 9,
+    "axes.linewidth": 0.8,
+    "axes.edgecolor": "#444444",
+    "xtick.labelsize": 8,
+    "ytick.labelsize": 8,
+    "xtick.major.width": 0.8,
+    "ytick.major.width": 0.8,
+    "legend.fontsize": 8,
+    "legend.frameon": False,
+    "mathtext.default": "regular",
+}
+
+_TRAIN_COLOR = "#2c3e8c"   # deep blue
+_VAL_COLOR = "#e08214"     # warm orange
+_TEST_COLOR = "#3a8a5f"    # green (test split in distribution panels)
+
+# Order components are laid out in; anything else is appended after these.
+_COMPONENT_ORDER = [
+    "total", "reconstruction", "kl_divergence",
+    "gene_abundance", "l1_regularization", "l2_regularization", "essential_gene",
+]
+
+_PRETTY_NAMES = {
+    "total": "Total loss",
+    "reconstruction": "Reconstruction (BCE)",
+    "kl_divergence": "KL divergence",
+    "gene_abundance": "Gene abundance",
+    "l1_regularization": "L1 regularisation",
+    "l2_regularization": "L2 regularisation",
+    "essential_gene": "Essential-gene",
+}
+
+
+def _pretty_component(name):
+    return _PRETTY_NAMES.get(name, name.replace("_", " ").capitalize())
+
+
+def plot_loss_components(train_losses, val_losses, fig_name, title=None):
+    """
+    Publication-quality breakdown of the VAE training loss into its components.
+
+    Renders one small-multiple panel per active loss component (total,
+    reconstruction, KL divergence, and any extra terms such as gene abundance
+    or L1), each with its own y-scale so terms of very different magnitude stay
+    readable. Train and validation curves share a single figure-level legend.
+
+    Parameters
+    ----------
+    train_losses, val_losses : dict[str, list[float]]
+        Per-epoch loss values keyed by component name, plus a 'total' key — i.e.
+        the LossTracker.train_losses / val_losses dicts produced during training.
+    fig_name : str
+        Output path. The format is inferred from the extension (.pdf, .png, ...).
+    title : str, optional
+        Figure suptitle (e.g. the preset name).
+    """
+    # Keep only components that were actually active (skip all-zero terms like a
+    # disabled L1), but always keep total/reconstruction/KL for context.
+    always = {"total", "reconstruction", "kl_divergence"}
+    ordered = [k for k in _COMPONENT_ORDER if k in train_losses]
+    ordered += [k for k in train_losses if k not in _COMPONENT_ORDER]
+
+    def _active(key):
+        series = train_losses.get(key, [])
+        return key in always or (len(series) > 0 and np.any(np.abs(series) > 1e-9))
+
+    components = [k for k in ordered if _active(k)]
+    if not components:
+        return
+
+    n = len(components)
+    ncols = 2 if n == 4 else min(n, 3)  # 4 terms read better as a balanced 2x2
+    nrows = int(np.ceil(n / ncols))
+
+    with plt.rc_context(_PUB_RC):
+        fig, axes = plt.subplots(
+            nrows, ncols,
+            figsize=(2.9 * ncols, 2.5 * nrows),
+            squeeze=False,
+            constrained_layout=True,
+        )
+        flat_axes = axes.flatten()
+        train_handle = val_handle = None
+
+        for ax, comp in zip(flat_axes, components):
+            tr = np.asarray(train_losses.get(comp, []), dtype=float)
+            va = np.asarray(val_losses.get(comp, []), dtype=float)
+            ep = np.arange(1, len(tr) + 1)
+            # For very short runs markers read better than thin lines.
+            marker = "o" if len(ep) <= 25 else None
+
+            (train_handle,) = ax.plot(
+                ep, tr, color=_TRAIN_COLOR, lw=1.6, marker=marker, ms=3, label="Train",
+            )
+            if len(va) == len(tr) and len(va) > 0:
+                (val_handle,) = ax.plot(
+                    ep, va, color=_VAL_COLOR, lw=1.6, ls="--", marker=marker, ms=3,
+                    label="Validation",
+                )
+
+            ax.set_title(_pretty_component(comp))
+            ax.grid(True, axis="both", ls=":", lw=0.6, alpha=0.45)
+            ax.spines["top"].set_visible(False)
+            ax.spines["right"].set_visible(False)
+            ax.margins(x=0.02)
+            ax.ticklabel_format(axis="y", style="sci", scilimits=(-3, 4))
+
+        # Shared axis labels along the figure edges.
+        for r in range(nrows):
+            axes[r][0].set_ylabel("Loss")
+        for c in range(ncols):
+            axes[nrows - 1][c].set_xlabel("Epoch")
+
+        # Blank any unused panels in the grid.
+        for ax in flat_axes[n:]:
+            ax.set_visible(False)
+
+        handles = [h for h in (train_handle, val_handle) if h is not None]
+        if handles:
+            # Bottom-centre legend stays clear of the title and any blank panels.
+            fig.legend(
+                handles=handles, loc="lower center", bbox_to_anchor=(0.5, -0.04),
+                ncol=len(handles),
+            )
+        if title:
+            fig.suptitle(title, fontsize=11, fontweight="bold")
+
+        fig.savefig(fig_name, bbox_inches="tight")
+        plt.close(fig)
+
+
 # Export all functions
 __all__ = [
     'create_dataloaders',
@@ -268,5 +407,6 @@ __all__ = [
     'l1_regularization',
     'cosine_annealing_schedule',
     'get_latent_variables',
-    'plot_loss_vs_epochs_graph'
+    'plot_loss_vs_epochs_graph',
+    'plot_loss_components'
 ]


### PR DESCRIPTION
Adds two figures rendered at the end of training (PDF for the paper + PNG), stacked on #8.

## Figures
- **`{preset}_loss_components`** — breaks the VAE loss into its parts (total, reconstruction, KL divergence, gene abundance, L1…) as small multiples, each on its own y-scale so terms of very different magnitude stay readable. The per-component histories were already tracked by `LossTracker` and discarded after training; now captured from the trainer with no change to its return signature.
- **`{preset}_training_summary`** — rebuilds the old 2×2 summary to publication quality and overlays **train vs test** on the per-sample reconstruction F1 and accuracy distributions (train metrics are a second `calculate_reconstruction_metrics` call), with a clean stats table replacing the grey text box.

Shared publication styling (fonts, palette, despined axes) lives in `extras.py`. The original `plot_loss_vs_epochs_graph` total-loss plot is kept unchanged.

## Verified on g6-big (L4)
Real runs of v1 (8 ep) and v3 (40 ep) produce both figures correctly, with all active loss components and real train-vs-test distributions.

> Stacked on #8 (base branch `claude/hf-setup-data`) because the figures are generated during training, which relies on the W&B-gating fix from that PR. Rebase onto `consolidate-rebuttle` once #8 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add publication-quality training visualizations for VAE runs, including a loss-component breakdown and an enhanced train/test training summary figure.

New Features:
- Generate a loss-component figure that decomposes VAE training loss into per-component small-multiple panels with shared publication styling.
- Produce an updated training summary figure that plots total loss and overlays train vs test reconstruction F1 and accuracy distributions with a compact stats table.
- Capture and store per-component loss histories and train-set reconstruction metrics during training to support the new plots.

Enhancements:
- Apply shared publication-oriented matplotlib styling and color palette across new training visualizations.